### PR TITLE
Add raw_sql() and bind()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ members = ["eloquent", "eloquent_core"]
 [dependencies]
 eloquent = { path = "eloquent", version = "2.0" }
 log = "0.4"
-ftail = "0.2"
+ftail = "0.3"

--- a/eloquent/Cargo.toml
+++ b/eloquent/Cargo.toml
@@ -11,5 +11,11 @@ keywords = ["database", "query", "sql"]
 [dependencies]
 eloquent_core = { path = "../eloquent_core", version = "2.0" }
 
+[features]
+default = []
+enable-raw = ["eloquent_core/enable-raw"]
+nullable-types = ["eloquent_core/nullable-types"]
+bind-placeholder-questionmark = ["eloquent_core/bind-placeholder-questionmark"]
+
 [lib]
 doctest = false

--- a/eloquent_core/Cargo.toml
+++ b/eloquent_core/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/tjardoo/eloquent-rs"
 documentation = "https://docs.rs/eloquent"
 
 [dependencies]
-sqlformat = "0.3.0"
+sqlformat = "0.5.0"
 log = "0.4"
 
 [lib]
@@ -17,5 +17,5 @@ doctest = true
 [features]
 default = []
 enable-raw = []
-bind-use-question-mark = []
-disable-option-to-sql = []
+nullable-types = []
+bind-placeholder-questionmark = []

--- a/eloquent_core/Cargo.toml
+++ b/eloquent_core/Cargo.toml
@@ -17,5 +17,5 @@ doctest = true
 [features]
 default = []
 enable-raw = []
-bind-use-question = []
+bind-use-question-mark = []
 disable-option-to-sql = []

--- a/eloquent_core/Cargo.toml
+++ b/eloquent_core/Cargo.toml
@@ -13,3 +13,9 @@ log = "0.4"
 
 [lib]
 doctest = true
+
+[features]
+default = []
+enable-raw = []
+bind-use-question = []
+disable-option-to-sql = []

--- a/eloquent_core/src/lib.rs
+++ b/eloquent_core/src/lib.rs
@@ -16,7 +16,10 @@ mod queries;
 mod query_builder;
 mod subqueries;
 mod subquery_builder;
+mod to_sql;
 mod validator;
+
+pub use to_sql::*;
 
 /// The main builder struct that holds all the query building information.
 pub struct QueryBuilder {
@@ -240,14 +243,16 @@ impl ToSql for &str {
 }
 
 impl ToSql for String {
+    #[inline(always)]
     fn to_sql(&self) -> Result<String, EloquentError> {
-        Ok(format!("'{}'", self.replace('\'', "''")))
+        self.as_str().to_sql()
     }
 }
 
 impl ToSql for &String {
+    #[inline(always)]
     fn to_sql(&self) -> Result<String, EloquentError> {
-        Ok(format!("'{}'", self.replace('\'', "''")))
+        self.as_str().to_sql()
     }
 }
 
@@ -290,6 +295,19 @@ impl ToSql for f64 {
 impl ToSql for bool {
     fn to_sql(&self) -> Result<String, EloquentError> {
         Ok(self.to_string())
+    }
+}
+
+#[cfg(not(feature = "disable-option-to-sql"))]
+impl<T> ToSql for Option<T>
+where
+    T: ToSql,
+{
+    fn to_sql(&self) -> Result<String, EloquentError> {
+        match self {
+            None => Ok(String::from("NULL")),
+            Some(value) => value.to_sql(),
+        }
     }
 }
 

--- a/eloquent_core/src/lib.rs
+++ b/eloquent_core/src/lib.rs
@@ -298,7 +298,7 @@ impl ToSql for bool {
     }
 }
 
-#[cfg(not(feature = "disable-option-to-sql"))]
+#[cfg(feature = "nullable-types")]
 impl<T> ToSql for Option<T>
 where
     T: ToSql,

--- a/eloquent_core/src/query_builder.rs
+++ b/eloquent_core/src/query_builder.rs
@@ -50,6 +50,7 @@ impl QueryBuilder {
             uppercase: Some(true),
             lines_between_queries: 2,
             ignore_case_convert: None,
+            ..Default::default()
         };
 
         let sql = sqlformat::format(&unformatted_sql, &sqlformat::QueryParams::None, &options);

--- a/eloquent_core/src/to_sql/bind.rs
+++ b/eloquent_core/src/to_sql/bind.rs
@@ -13,7 +13,6 @@ pub struct Bind(u32);
 ///     .table("flights")
 ///     .r#where("airline_id", bind(7));
 ///
-/// #[cfg(feature = "bind-use-question")]
 /// assert_eq!(
 ///     result.sql().unwrap(),
 ///     "SELECT * FROM flights WHERE airline LIKE ?2"

--- a/eloquent_core/src/to_sql/bind.rs
+++ b/eloquent_core/src/to_sql/bind.rs
@@ -5,12 +5,12 @@ pub struct Bind(u32);
 
 /// Use a parameter binding for this value instead of a literal.
 ///
-/// Requires feature `bind-use-question-mark`.
+/// Requires feature `bind-placeholder-questionmark`.
 ///
-/// You can use the feature `bind-use-question-mark` to control the use of '$' vs '?' for formatting.
+/// You can use the feature `bind-placeholder-questionmark` to control the use of '$' vs '?' for formatting.
 ///
 #[cfg_attr(
-    not(feature = "bind-use-question-mark"),
+    not(feature = "bind-placeholder-questionmark"),
     doc = r##"/// ```
 /// use eloquent_core::{QueryBuilder, bind};
 ///
@@ -31,9 +31,7 @@ pub fn bind(index: u32) -> Bind {
 
 impl ToSql for Bind {
     fn to_sql(&self) -> Result<String, EloquentError> {
-        eprintln!("--> bind = {}", self.0);
-
-        if cfg!(feature = "bind-use-question-mark") {
+        if cfg!(feature = "bind-placeholder-questionmark") {
             Ok(format!("?{}", self.0))
         } else {
             Ok(format!("${}", self.0))
@@ -53,13 +51,13 @@ mod tests {
     use crate::QueryBuilder;
 
     #[test]
-    #[cfg(not(feature = "bind-use-question-mark"))]
+    #[cfg(not(feature = "bind-placeholder-questionmark"))]
     fn test_bind_dollar_sign() {
         assert_eq!(bind(2).to_sql(), Ok(String::from("$2")));
     }
 
     #[test]
-    #[cfg(not(feature = "bind-use-question-mark"))]
+    #[cfg(not(feature = "bind-placeholder-questionmark"))]
     fn test_bind_query_builder_delete() {
         let query = QueryBuilder::new()
             .table("flights")
@@ -70,7 +68,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "bind-use-question-mark"))]
+    #[cfg(not(feature = "bind-placeholder-questionmark"))]
     fn test_bind_query_builder_insert() {
         let query = QueryBuilder::new().table("flights").insert("name", bind(2));
 
@@ -81,7 +79,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "bind-use-question-mark")]
+    #[cfg(feature = "bind-placeholder-questionmark")]
     fn test_bind_query_builder_insert() {
         let query = QueryBuilder::new().table("flights").insert("name", bind(4));
 
@@ -92,7 +90,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "bind-use-question-mark")]
+    #[cfg(feature = "bind-placeholder-questionmark")]
     fn test_bind_question_mark() {
         assert_eq!(bind(7).to_sql(), Ok(String::from("?7")));
     }

--- a/eloquent_core/src/to_sql/bind.rs
+++ b/eloquent_core/src/to_sql/bind.rs
@@ -1,0 +1,116 @@
+use crate::{EloquentError, ToSql};
+
+#[derive(Debug)]
+pub struct Bind(u32);
+
+/// Use a parameter binding for this value instead of a literal
+#[cfg_attr(
+    not(feature = "bind-use-question"),
+    doc = r##"/// ```
+/// use eloquent_core::{QueryBuilder, bind};
+///
+/// let result = QueryBuilder::new()
+///     .table("flights")
+///     .r#where("airline_id", bind(7));
+///
+/// #[cfg(feature = "bind-use-question")]
+/// assert_eq!(
+///     result.sql().unwrap(),
+///     "SELECT * FROM flights WHERE airline LIKE ?2"
+/// );
+/// ```
+"##
+)]
+#[cfg_attr(
+    not(feature = "bind-use-question"),
+    doc = r##"
+/// ```
+/// use eloquent_core::{QueryBuilder, bind};
+///
+/// let result = QueryBuilder::new()
+///     .table("flights")
+///     .r#where("airline_id", bind(7));
+///
+/// assert_eq!(
+///     result.sql().unwrap(),
+///     "SELECT * FROM flights WHERE airline LIKE $2"
+/// );
+/// ```        
+"##
+)]
+///
+/// Notes:
+/// Requires te `enable-bind` feature to be enabled
+/// You can use the feature `bind-use-question` to control the use of
+/// '$' vs '?' for formatting.
+pub fn bind(index: u32) -> Bind {
+    Bind(index)
+}
+
+impl ToSql for Bind {
+    fn to_sql(&self) -> Result<String, EloquentError> {
+        eprintln!("--> bind = {}", self.0);
+        if cfg!(feature = "bind-use-question") {
+            Ok(format!("?{}", self.0))
+        } else {
+            Ok(format!("${}", self.0))
+        }
+    }
+}
+
+impl std::fmt::Display for Bind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "bind({})", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::QueryBuilder;
+
+    #[test]
+    #[cfg(not(feature = "bind-use-question"))]
+    fn test_bind_dollar_sign() {
+        assert_eq!(bind(2).to_sql(), Ok(String::from("$2")));
+    }
+
+    #[test]
+    #[cfg(not(feature = "bind-use-question"))]
+    fn test_bind_query_builder_delete() {
+        let query = QueryBuilder::new()
+            .table("flights")
+            .delete()
+            .r#where("id", bind(2));
+
+        assert_eq!(query.to_sql().unwrap(), "DELETE FROM flights WHERE id = $2");
+    }
+
+    #[test]
+    #[cfg(not(feature = "bind-use-question"))]
+    fn test_bind_query_builder_insert() {
+        let query = QueryBuilder::new().table("flights").insert("name", bind(2));
+
+        assert_eq!(
+            query.to_sql().unwrap(),
+            "INSERT INTO flights (name) VALUES ($2)"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "bind-use-question")]
+    fn test_bind_query_builder_insert() {
+        let query = QueryBuilder::new().table("flights").insert("name", bind(4));
+
+        assert_eq!(
+            query.to_sql().unwrap(),
+            "INSERT INTO flights (name) VALUES (?4)"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "bind-use-question")]
+    fn test_bind_question_mark() {
+        assert_eq!(bind(7).to_sql(), Ok(String::from("?7")));
+    }
+}

--- a/eloquent_core/src/to_sql/mod.rs
+++ b/eloquent_core/src/to_sql/mod.rs
@@ -7,7 +7,7 @@ mod raw_sql;
 pub use raw_sql::raw_sql;
 
 #[cfg(test)]
-#[cfg(not(feature = "disable-option-to-sql"))]
+#[cfg(feature = "nullable-types")]
 mod tests {
     #[test]
     fn test_option_none_to_sql() {

--- a/eloquent_core/src/to_sql/mod.rs
+++ b/eloquent_core/src/to_sql/mod.rs
@@ -12,18 +12,21 @@ mod tests {
     #[test]
     fn test_option_none_to_sql() {
         use crate::ToSql;
+
         assert_eq!(Option::<bool>::None.to_sql().unwrap(), "NULL");
     }
 
     #[test]
     fn test_option_u32_to_sql() {
         use crate::ToSql;
+
         assert_eq!(Some(11).to_sql().unwrap(), "11");
     }
 
     #[test]
     fn test_option_str_to_sql() {
         use crate::ToSql;
+
         assert_eq!(Some("text").to_sql().unwrap(), "'text'");
     }
 }

--- a/eloquent_core/src/to_sql/mod.rs
+++ b/eloquent_core/src/to_sql/mod.rs
@@ -1,0 +1,29 @@
+mod bind;
+pub use bind::bind;
+
+#[cfg(feature = "enable-raw")]
+mod raw_sql;
+#[cfg(feature = "enable-raw")]
+pub use raw_sql::raw_sql;
+
+#[cfg(test)]
+#[cfg(not(feature = "disable-option-to-sql"))]
+mod tests {
+    #[test]
+    fn test_option_none_to_sql() {
+        use crate::ToSql;
+        assert_eq!(Option::<bool>::None.to_sql().unwrap(), "NULL");
+    }
+
+    #[test]
+    fn test_option_u32_to_sql() {
+        use crate::ToSql;
+        assert_eq!(Some(11).to_sql().unwrap(), "11");
+    }
+
+    #[test]
+    fn test_option_str_to_sql() {
+        use crate::ToSql;
+        assert_eq!(Some("text").to_sql().unwrap(), "'text'");
+    }
+}

--- a/eloquent_core/src/to_sql/raw_sql.rs
+++ b/eloquent_core/src/to_sql/raw_sql.rs
@@ -3,8 +3,9 @@ use crate::{EloquentError, ToSql};
 #[derive(Debug)]
 pub struct RawSql(String);
 
-/// Inject a raw SQ: value into the query
-/// Note: This is an safe function as it can cause the query to misbehave
+/// Inject a raw SQL value into the query. This is an unsafe function as it can cause the query to misbehave.
+///
+/// Requires feature `enable-raw`.
 ///
 /// ```
 /// use eloquent_core::{QueryBuilder, raw_sql};
@@ -17,9 +18,7 @@ pub struct RawSql(String);
 ///     result.sql().unwrap(),
 ///     "INSERT INTO flights (hash) VALUES ('some_hash'::bytea)"
 /// );
-/// ```    
-///
-/// Requires te `enable-raw` feature to be enabled
+/// ```
 //
 pub unsafe fn raw_sql<S>(sql: S) -> RawSql
 where

--- a/eloquent_core/src/to_sql/raw_sql.rs
+++ b/eloquent_core/src/to_sql/raw_sql.rs
@@ -1,0 +1,69 @@
+use crate::{EloquentError, ToSql};
+
+#[derive(Debug)]
+pub struct RawSql(String);
+
+/// Inject a raw SQ: value into the query
+/// Note: This is an safe function as it can cause the query to misbehave
+///
+/// ```
+/// use eloquent_core::{QueryBuilder, raw_sql};
+///
+/// let result = QueryBuilder::new()
+///     .table("flights")
+///     .insert("hash", unsafe { raw_sql("'some_hash'::bytea") });
+///
+/// assert_eq!(
+///     result.sql().unwrap(),
+///     "INSERT INTO flights (hash) VALUES ('some_hash'::bytea)"
+/// );
+/// ```    
+///
+/// Requires te `enable-raw` feature to be enabled
+//
+pub unsafe fn raw_sql<S>(sql: S) -> RawSql
+where
+    S: Into<String>,
+{
+    RawSql(sql.into())
+}
+
+impl ToSql for RawSql {
+    fn to_sql(&self) -> Result<String, EloquentError> {
+        Ok(self.0.clone())
+    }
+}
+
+impl std::fmt::Display for RawSql {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SQL({})", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::QueryBuilder;
+
+    #[test]
+    fn test_raw_sql() {
+        assert_eq!(
+            unsafe { raw_sql("'{}'::jsonb").to_sql() },
+            Ok(String::from("'{}'::jsonb"))
+        );
+    }
+
+    #[test]
+    fn test_raw_query_builder_insert() {
+        unsafe {
+            let query = QueryBuilder::new()
+                .table("flights")
+                .insert("metadata", raw_sql(r#"'{"name":"value"}'::json"#));
+
+            assert_eq!(
+                query.to_sql().unwrap(),
+                r#"INSERT INTO flights (metadata) VALUES ('{"name":"value"}'::json)"#
+            );
+        }
+    }
+}


### PR DESCRIPTION
Adds two functions `bind` and `raw_sql` which can be used to provided parameters and raw SQL into the query builder.

Note using  `raw_sql` is controlled with the "enable-raw" feature, this is intentional since it's dangerous users should have to opt-in.

Example of bind:
```
use eloquent_core::{QueryBuilder, bind};

let result = QueryBuilder::new()
     .table("flights")
     .r#where("airline_id", bind(7));

     assert_eq!(
     result.sql().unwrap(),
     "SELECT * FROM flights WHERE airline LIKE $2"
 );
 ```

Example of raw_sql:

```
 use eloquent_core::{QueryBuilder, raw_sql};

 let result = QueryBuilder::new()
     .table("flights")
     .insert("hash", unsafe { raw_sql("'some_hash'::bytea") });

    assert_eq!(
     result.sql().unwrap(),
     "INSERT INTO flights (hash) VALUES ('some_hash'::bytea)"
 );
 ```    
